### PR TITLE
Update MicrosoftTeamsTransport.php

### DIFF
--- a/MicrosoftTeamsTransport.php
+++ b/MicrosoftTeamsTransport.php
@@ -59,9 +59,7 @@ final class MicrosoftTeamsTransport extends AbstractTransport
         $path = $message->getRecipientId() ?? $this->path;
         $endpoint = sprintf('https://%s%s', $this->getEndpoint(), $path);
         $response = $this->client->request('POST', $endpoint, [
-            'json' => [
-                'title' => $message->getSubject(),
-            ],
+            'json' => json_decode($message->getSubject())
         ]);
 
         $requestId = $response->getHeaders(false)['request-id'][0] ?? null;


### PR DESCRIPTION
Code caused following error - 'Unable to post the Microsoft Teams message: ... Summary or Text is required. '. The structure of the message needs to fit the templates defined by Microsoft Teams. Attribute $message->subject is specified as string, json_decode($message->getSubject()) solve the issue and helps generate fully defined cards in Teams canals.