### PR TITLE
JSON structure error fix for simple message

### DIFF
--- a/MicrosoftTeamsTransport.php
+++ b/MicrosoftTeamsTransport.php
@@ -60,7 +60,7 @@ final class MicrosoftTeamsTransport extends AbstractTransport
         $endpoint = sprintf('https://%s%s', $this->getEndpoint(), $path);
         $response = $this->client->request('POST', $endpoint, [
             'json' => [
-                'title' => $message->getSubject(),
+                'text' => $message->getSubject(),
             ],
         ]);
 


### PR DESCRIPTION
Code caused following error - 'Unable to post the Microsoft Teams message: ... Summary or Text is required. '. The structure of the message should contain the 'text' attribute instead of 'title'.